### PR TITLE
Refactor CI workflow by moving release steps to a new publish.yml file

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -152,35 +152,5 @@ jobs:
           name: wheels-sdist
           path: dist
 
-  release:
-    name: Release
-    runs-on: ubuntu-latest
-    if: ${{ startsWith(github.ref, 'refs/tags/') || github.event_name == 'workflow_dispatch' }}
-    needs: [linux, musllinux, windows, macos, sdist]
-    permissions:
-      # Use to sign the release artifacts
-      id-token: write
-      # Used to upload release artifacts
-      contents: write
-      # Used to generate artifact attestation
-      attestations: write
-    steps:
-      - uses: actions/download-artifact@v4
-      - name: Generate artifact attestation
-        uses: actions/attest-build-provenance@v2
-        with:
-          subject-path: 'wheels-*/*'
-      - name: Publish to PyPI
-        if: ${{ startsWith(github.ref, 'refs/tags/') }}
-        uses: PyO3/maturin-action@v1
-        env:
-          MATURIN_PYPI_TOKEN: ${{ secrets.PYPI_API_TOKEN }}
-        with:
-          command: upload
-          args: --non-interactive --skip-existing wheels-*/*
-      # - name: Upload to GitHub Release
-      #   uses: softprops/action-gh-release@v1
-      #   with:
-      #     files: |
-      #       wasm-wheels/*.whl
-      #     prerelease: ${{ contains(github.ref, 'alpha') || contains(github.ref, 'beta') }}
+  # Release step moved to separate publish.yml workflow
+  # This allows for more flexible publishing options and manual control

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,81 @@
+name: Publish Package
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Version to publish (e.g., 1.0.0)'
+        required: true
+        type: string
+      publish_to_pypi:
+        description: 'Publish to PyPI'
+        required: false
+        type: boolean
+        default: true
+      create_github_release:
+        description: 'Create GitHub Release'
+        required: false
+        type: boolean
+        default: true
+  push:
+    tags:
+      - 'v*'
+
+permissions:
+  contents: write
+  id-token: write
+  attestations: write
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0  # Fetch all history for tags
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: 3.x
+
+      - name: Download all artifacts
+        uses: actions/download-artifact@v4
+        with:
+          pattern: wheels-*
+          merge-multiple: true
+
+      - name: Generate artifact attestation
+        uses: actions/attest-build-provenance@v2
+        with:
+          subject-path: 'wheels-*/*'
+
+      - name: Publish to PyPI
+        if: ${{ github.event.inputs.publish_to_pypi != 'false' && (startsWith(github.ref, 'refs/tags/') || github.event.inputs.publish_to_pypi == 'true') }}
+        uses: PyO3/maturin-action@v1
+        env:
+          MATURIN_PYPI_TOKEN: ${{ secrets.PYPI_API_TOKEN }}
+        with:
+          command: upload
+          args: --non-interactive --skip-existing wheels-*/*
+
+      - name: Create GitHub Release
+        if: ${{ github.event.inputs.create_github_release != 'false' && (startsWith(github.ref, 'refs/tags/') || github.event.inputs.create_github_release == 'true') }}
+        uses: softprops/action-gh-release@v1
+        with:
+          files: |
+            wheels-*/*.whl
+            wheels-sdist/*.tar.gz
+          prerelease: ${{ contains(github.ref, 'alpha') || contains(github.ref, 'beta') || contains(github.ref, 'rc') }}
+          generate_release_notes: true
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Output summary
+        run: |
+          echo "## Publish Summary" >> $GITHUB_STEP_SUMMARY
+          echo "- **Trigger**: ${{ github.event_name }}" >> $GITHUB_STEP_SUMMARY
+          echo "- **Version**: ${{ github.event.inputs.version || github.ref_name }}" >> $GITHUB_STEP_SUMMARY
+          echo "- **PyPI Published**: ${{ github.event.inputs.publish_to_pypi != 'false' && (startsWith(github.ref, 'refs/tags/') || github.event.inputs.publish_to_pypi == 'true') }}" >> $GITHUB_STEP_SUMMARY
+          echo "- **GitHub Release**: ${{ github.event.inputs.create_github_release != 'false' && (startsWith(github.ref, 'refs/tags/') || github.event.inputs.create_github_release == 'true') }}" >> $GITHUB_STEP_SUMMARY


### PR DESCRIPTION
- Removed the release job from CI.yml to streamline the workflow.
- Introduced a new publish.yml file for flexible publishing options, including manual control over PyPI publishing and GitHub releases.
- Updated permissions and steps to accommodate the new structure.

These changes improve the organization of the CI/CD process and enhance the ability to manage releases effectively.