### PR TITLE
Update CI workflow to enhance artifact handling and publishing steps

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -40,16 +40,19 @@ jobs:
         with:
           python-version: 3.x
 
-      - name: Download all artifacts
-        uses: actions/download-artifact@v4
+      - name: Download artifacts from latest CI run
+        uses: dawidd6/action-download-artifact@v3
         with:
-          pattern: wheels-*
-          merge-multiple: true
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          workflow: CI.yml
+          workflow_conclusion: success
+          name: wheels-linux-x86_64,wheels-linux-x86,wheels-linux-aarch64,wheels-linux-armv7,wheels-linux-s390x,wheels-linux-ppc64le,wheels-musllinux-x86_64,wheels-musllinux-x86,wheels-musllinux-aarch64,wheels-musllinux-armv7,wheels-windows-x64,wheels-windows-x86,wheels-macos-x86_64,wheels-macos-aarch64,wheels-sdist
+          path: artifacts
 
       - name: Generate artifact attestation
         uses: actions/attest-build-provenance@v2
         with:
-          subject-path: 'wheels-*/*'
+          subject-path: 'artifacts/*'
 
       - name: Publish to PyPI
         if: ${{ github.event.inputs.publish_to_pypi != 'false' && (startsWith(github.ref, 'refs/tags/') || github.event.inputs.publish_to_pypi == 'true') }}
@@ -58,15 +61,15 @@ jobs:
           MATURIN_PYPI_TOKEN: ${{ secrets.PYPI_API_TOKEN }}
         with:
           command: upload
-          args: --non-interactive --skip-existing wheels-*/*
+          args: --non-interactive --skip-existing artifacts/*/*
 
       - name: Create GitHub Release
         if: ${{ github.event.inputs.create_github_release != 'false' && (startsWith(github.ref, 'refs/tags/') || github.event.inputs.create_github_release == 'true') }}
         uses: softprops/action-gh-release@v1
         with:
           files: |
-            wheels-*/*.whl
-            wheels-sdist/*.tar.gz
+            artifacts/*/*.whl
+            artifacts/wheels-sdist/*.tar.gz
           prerelease: ${{ contains(github.ref, 'alpha') || contains(github.ref, 'beta') || contains(github.ref, 'rc') }}
           generate_release_notes: true
         env:


### PR DESCRIPTION
- Changed the artifact download step to use a more specific action for better control over the latest CI run artifacts.
- Updated paths for artifact generation and publishing to reflect the new structure, ensuring consistency in the workflow.
- Improved the organization of the publish process by specifying artifact locations for both PyPI uploads and GitHub releases.

These changes streamline the CI/CD process and enhance the reliability of artifact management.